### PR TITLE
Add CMakeLists.txt file for crossplatform builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+
+project(
+    WeatherAnalysis
+    LANGUAGES CXX
+)
+
+add_library(Functions Functions.cpp Functions.h)
+add_executable(WeatherAnalysis main.cpp)
+target_link_libraries(WeatherAnalysis PRIVATE Functions)


### PR DESCRIPTION
# What does this do?
This adds a CMakeLists.txt file to allow for crossplatform builds of the program.

# How to test
Run the following (on windows you must have CMake installed and use powershell instead of command prompt to run these)
```
mkdir build
cd build
cmake ..
make
cd ..
./build/WeatherAnalysis
```